### PR TITLE
chore(ci): Node24 대비 액션 버전 bump (checkout v5, setup-python v6)

### DIFF
--- a/.github/workflows/link-rot.yml
+++ b/.github/workflows/link-rot.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Check links in posts (lychee)
         id: lychee

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           # submodules: true

--- a/.github/workflows/seo-check.yml
+++ b/.github/workflows/seo-check.yml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Node 20 액션 deprecation 대응

GitHub가 **2026-06-16부터 Node 24 강제**. 워크플로 로그 annotation서 `actions/checkout@v4`·`actions/setup-python@v5`(Node 20) 경고 확인.

### 변경
- `actions/checkout@v4 → v5` (pages-deploy·seo-check×2·link-rot, 총 4곳)
- `actions/setup-python@v5 → v6` (seo-check)
- 미플래그 액션(configure-pages·upload/deploy-pages·setup-ruby·lychee)은 호환이라 유지

### 왜 중요
**pages-deploy**는 예약발행 cron 핵심 — 06-16 이후 안 깨지게 선제 조치. 이 PR의 CI 통과 = 새 액션 버전 실증.

🤖 Generated with [Claude Code](https://claude.com/claude-code)